### PR TITLE
attempting to reference a deleted function fix

### DIFF
--- a/include/injector/assembly.hpp
+++ b/include/injector/assembly.hpp
@@ -152,14 +152,14 @@ namespace injector
     template<uintptr_t at, uintptr_t end, class FuncT>
     void MakeInline(FuncT func)
     {
-        static FuncT static_func = func;    // Stores the func object
-        static_func = func;                 //
+        static std::unique_ptr<FuncT> static_func;
+        static_func.reset(new FuncT(std::move(func)));
 
         // Encapsulates the call to static_func
         struct Caps
         {
             void operator()(reg_pack& regs)
-            { static_func(regs); }
+            { (*static_func)(regs); }
         };
 
         // Does the actual MakeInline


### PR DESCRIPTION
This code was in p2dfx for quite a while, perhaps no reason not to update main repo?

Severity	Code	Description	Project	File	Line	Suppression State
Error	C2280	'CLODLightManager::III::ApplyMemoryPatches::<lambda_50ecc6102f46523f5d56a05d84c8a2fa> &CLODLightManager::III::ApplyMemoryPatches::<lambda_50ecc6102f46523f5d56a05d84c8a2fa>::operator =(const CLODLightManager::III::ApplyMemoryPatches::<lambda_50ecc6102f46523f5d56a05d84c8a2fa> &)': attempting to reference a deleted function	IIILodLights	external\injector\include\injector\assembly.hpp	156	
