### PR TITLE
makeinline after cmp fix

### DIFF
--- a/include/injector/assembly.hpp
+++ b/include/injector/assembly.hpp
@@ -43,15 +43,15 @@ namespace injector
         // The ordering is very important, don't change
         // The first field is the last to be pushed and first to be poped
 
-        // PUSHFD / POPFD
-        uint32_t ef;
-
         // PUSHAD/POPAD -- must be the lastest fields (because of esp)
         union
         {
             uint32_t arr[8];
             struct { uint32_t edi, esi, ebp, esp, ebx, edx, ecx, eax; };
         };
+
+        // PUSHFD / POPFD
+        uint32_t ef;
         
         enum reg_name {
             reg_edi, reg_esi, reg_ebp, reg_esp, reg_ebx, reg_edx, reg_ecx, reg_eax 
@@ -100,9 +100,9 @@ namespace injector
             _asm
             {
                 // Construct the reg_pack structure on the stack
-                pushad              // Pushes general purposes registers to reg_pack
-                add dword ptr[esp+12], 4     // Add 4 to reg_pack::esp 'cuz of our return pointer, let it be as before this func is called
                 pushfd              // Pushes EFLAGS to reg_pack
+                pushad              // Pushes general purposes registers to reg_pack
+                add dword ptr[esp+12], 8     // Add 4 to reg_pack::esp 'cuz of our return pointer, let it be as before this func is called
 
                 // Call wrapper sending reg_pack as parameter
                 push esp
@@ -110,9 +110,9 @@ namespace injector
                 add esp, 4
 
                 // Destructs the reg_pack from the stack
-                sub dword ptr[esp+12+4], 4   // Fix reg_pack::esp before popping it (doesn't make a difference though) (+4 because eflags)
-                popfd               // Warning: Do not use any instruction that changes EFLAGS after this (-> sub affects EF!! <-)
+                sub dword ptr[esp+12], 8   // Fix reg_pack::esp before popping it (doesn't make a difference though) (+4 because eflags)
                 popad
+                popfd               // Warning: Do not use any instruction that changes EFLAGS after this (-> sub affects EF!! <-)
 
                 // Back to normal flow
                 ret


### PR DESCRIPTION
For example, in Silent Hill 3, the following code would alter original function's behavior:

```
.text:005F1D10 3D E4 FA 71 00                                cmp     eax, offset unk_71FAE4
.text:005F1D15 D9 59 E8                                      fstp    dword ptr [ecx-18h]
.text:005F1D18 D9 C0                                         fld     st
.text:005F1D1A D8 48 F8                                      fmul    dword ptr [eax-8]
.text:005F1D1D D9 59 EC                                      fstp    dword ptr [ecx-14h]
.text:005F1D20 7C DE                                         jl      short loc_5F1D00
```

```
    pattern = hook::pattern("D9 59 E8 D9 C0 D8 48 F8 D9 59 EC 7C DE 6A 01"); //5F1D15
    struct HealthHook
    {
        void operator()(injector::reg_pack& regs)
        {
            float temp = 0.0f;
            _asm {fstp dword ptr ds : [temp]}
            *(float*)(regs.ecx - 0x18) = temp;
            _asm {fld st}
        }
    }; injector::MakeInline<HealthHook>(pattern.get_first(0));
```

so in order for it work properly, makeinline can't be placed between cmp and jl instructions:
```
    char bytes[5] = { 0 };
    pattern = hook::pattern("D9 59 E8 D9 C0 D8 48 F8 D9 59 EC 7C DE 6A 01"); //5F1D15
    injector::ReadMemoryRaw(pattern.get_first(-5), bytes, sizeof(bytes), true);
    struct HealthHook
    {
        void operator()(injector::reg_pack& regs)
        {
            float temp = 0.0f;
            _asm {fstp dword ptr ds : [temp]}
            *(float*)(regs.ecx - 0x18) = temp;
            _asm {fld st}
        }
    }; injector::MakeInline<HealthHook>(pattern.get_first(-5), pattern.get_first(5));
injector::WriteMemoryRaw(pattern.get_first(0), bytes, sizeof(bytes), true); //cmp eax, offset unk_71FAE4
```

This PR aims to fix that behavior, so both examples will work the same way.